### PR TITLE
Avoid stringifying struct keys

### DIFF
--- a/lib/ex_admin/repo.ex
+++ b/lib/ex_admin/repo.ex
@@ -355,6 +355,7 @@ res
     res
   end
 
+  def param_stringify_keys(%{__struct__: _}=params), do: params
   def param_stringify_keys(params) when is_map(params) do
     Map.to_list(params)
     |> Enum.map(fn {key, value} -> {stringify_key(key), param_stringify_keys(value)} end)


### PR DESCRIPTION
I was getting an strange error when trying to upload file using ExAdmin with Arc:

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Arc.File.new/1
        lib/arc/file.ex:5: Arc.File.new(%{"__struct__" => Plug.Upload, "content_type" => "image/jpeg", "filename" => "capture_preview.jpg", "path" => "/tmp/plug-1469/multipart-581271-216409-2"})
```

After a while debugging I've found that the `param_stringify_keys` were the problem.
Fixed it here, I think more people should have problem with that. (I can explain my whole setup if you aren't able to reproduce this)
